### PR TITLE
update podspec to match twilio's ios platform target

### DIFF
--- a/RCTTwilioIPMessaging.podspec
+++ b/RCTTwilioIPMessaging.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
 
   s.license      = "MIT"
   s.authors      = { "Brad Bumbalough" => "bradley.bumbalough@gmail.com" }
-  s.platform     = :ios, "9.0"
+  s.platform     = :ios, "8.1"
 
   s.source       = { :git => "https://github.com/ccm-innovation/react-native-twilio-ip-messaging.git" }
 


### PR DESCRIPTION
There's no reason to have the target be as high as iOS 9.0, and Twilio's IPMessagingClient only requires a minimum target of 8.1.

Would it be possible to merge this directly into master? Would simplify a lot of installation for people who need to target older versions of iOS.

Great job on the library, by the way.
