### PR TITLE
fix bug in setFriendlyName and setAttributes

### DIFF
--- a/RCTTwilioIPMessaging/RCTTwilioIPMessagingClient.m
+++ b/RCTTwilioIPMessaging/RCTTwilioIPMessagingClient.m
@@ -93,18 +93,21 @@ RCT_EXPORT_METHOD(logLevel:(TWMLogLevel)logLevel callback:(RCTResponseSenderBloc
 RCT_REMAP_METHOD(setFriendlyName, friendlyName:(NSString *)friendlyName friendlyName_resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
   RCTTwilioIPMessagingClient *_client = [RCTTwilioIPMessagingClient sharedManager];
   [[[_client client]userInfo] setFriendlyName:friendlyName completion:^(TWMResult *result) {
-    if (!result.isSuccessful) {
+    if (result.isSuccessful) {
       resolve(@[@TRUE]);
     }
+    // Should replace this with a more descriptive error message
+    reject(@[@FALSE]);
   }];
 }
 
 RCT_REMAP_METHOD(setAttributes, attributes:(NSDictionary *)attributes attributes_resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
   RCTTwilioIPMessagingClient *_client = [RCTTwilioIPMessagingClient sharedManager];
   [[[_client client]userInfo] setAttributes:attributes completion:^(TWMResult *result) {
-    if (!result.isSuccessful) {
+    if (result.isSuccessful) {
       resolve(@[@TRUE]);
     }
+    reject(@[@FALSE]);
   }];
 }
 


### PR DESCRIPTION
Was using your library and noticed this `isSuccessful` was accidentally negated. Changed it also for `setAttributes` but not sure where else could have an issue.

In the future, it would be best to have all of the Promise returning methods explicitly reject on failure, otherwise it will cause anything waiting on the Promise to block forever.
