### PR TITLE
Convert hex string to NSData for device token.

### DIFF
--- a/RCTTwilioIPMessaging/RCTConvert+TwilioIPMessagingClient.h
+++ b/RCTTwilioIPMessaging/RCTConvert+TwilioIPMessagingClient.h
@@ -30,4 +30,6 @@
 + (NSArray *)TWMMembers:(NSArray<TWMMember *>*)members;
 + (NSArray *)TWMMessages:(NSArray<TWMMessage *> *)messages;
 
++ (NSData *)dataWithHexString:(NSString*)hex;
+
 @end

--- a/RCTTwilioIPMessaging/RCTConvert+TwilioIPMessagingClient.m
+++ b/RCTTwilioIPMessaging/RCTConvert+TwilioIPMessagingClient.m
@@ -155,5 +155,23 @@ RCT_ENUM_CONVERTER(TWMLogLevel,(@{
   return response;
 }
 
++ (NSData *)dataWithHexString:(NSString *)hex {
+  // Source:  https://opensource.apple.com/source/Security/Security-55471.14.18/libsecurity_transform/NSData+HexString.m
+  char buf[3];
+  buf[2] = '\0';
+  NSAssert(0 == [hex length] % 2, @"Hex strings should have an even number of digits (%@)", hex);
+  unsigned char *bytes = malloc([hex length]/2);
+  unsigned char *bp = bytes;
+  for (CFIndex i = 0; i < [hex length]; i += 2) {
+      buf[0] = [hex characterAtIndex:i];
+      buf[1] = [hex characterAtIndex:i+1];
+      char *b2 = NULL;
+      *bp++ = strtol(buf, &b2, 16);
+      NSAssert(b2 == buf + 2, @"String should be all hex digits: %@ (bad digit around %d)", hex, i);
+  }
+
+  return [NSData dataWithBytesNoCopy:bytes length:[hex length]/2 freeWhenDone:YES];
+}
+
 
 @end

--- a/RCTTwilioIPMessaging/RCTTwilioIPMessagingClient.m
+++ b/RCTTwilioIPMessaging/RCTTwilioIPMessagingClient.m
@@ -62,14 +62,14 @@ RCT_EXPORT_METHOD(version:(RCTResponseSenderBlock)callback) {
   callback(@[client.version]);
 }
 
-RCT_EXPORT_METHOD(registerWithToken:(NSData *)token) {
+RCT_EXPORT_METHOD(registerWithToken:(NSString *)token) {
   RCTTwilioIPMessagingClient *_client = [RCTTwilioIPMessagingClient sharedManager];
-  [[_client client] registerWithToken:token];
+  [[_client client] registerWithToken:[RCTConvert dataWithHexString:token]];
 }
 
-RCT_EXPORT_METHOD(deregisterWithToken:(NSData *)token) {
+RCT_EXPORT_METHOD(deregisterWithToken:(NSString *)token) {
   RCTTwilioIPMessagingClient *_client = [RCTTwilioIPMessagingClient sharedManager];
-  [[_client client] deregisterWithToken:token];
+  [[_client client] deregisterWithToken:[RCTConvert dataWithHexString:token]];
 }
 
 RCT_EXPORT_METHOD(handleNotification:(NSDictionary *)notification) {


### PR DESCRIPTION
The `registerWithToken` method doesn't correctly convert the device token (inputed as a hex `NSString`) to an `NSData` object. This causes Twilio to report that the APNs token has an invalid format and push notifications don't go through. See: https://www.twilio.com/docs/api/errors/52134

With this change, I convert convert the hex `NSString` to an `NSData` object before passing it to the Twilio SDK and am able to successfully receive push notifications.

Thanks for creating this bridge!
