### PR TITLE
change remap to export for createClient

### DIFF
--- a/ios/RCTTwilioIPMessaging/RCTTwilioIPMessagingClient.m
+++ b/ios/RCTTwilioIPMessaging/RCTTwilioIPMessagingClient.m
@@ -34,7 +34,7 @@
 
 RCT_EXPORT_MODULE()
 
-RCT_REMAP_METHOD(createClient, properties:(NSDictionary *)properties resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject){
+RCT_EXPORT_METHOD(createClient:(NSDictionary *)properties resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject){
   TwilioAccessManager *accessManager = [[RCTTwilioAccessManager sharedManager] accessManager];
   // TODO add check to see if AccessManager has been initialized or not
   TwilioIPMessagingClientProperties *props = nil;
@@ -110,7 +110,7 @@ RCT_REMAP_METHOD(setAttributes, attributes:(NSDictionary *)attributes attributes
     }
     else {
       reject(@"set-attributes-error", @"Error occured while attempting to set attributes for the user.", result.error);
-    }  
+    }
   }];
 }
 


### PR DESCRIPTION
Remap needs to be export on `createClient`, since it doesn't actually exist in Twilio's SDK. Please verify this works on your end - I was unable to get my forked version of your repo working with my project since I'm terrible with cocoapods.
