### PR TITLE
fix typos and method names

### DIFF
--- a/docs/Channel.md
+++ b/docs/Channel.md
@@ -51,7 +51,7 @@ Synchronize the channel with the server. May not be needed depending on if you s
 #### `setAttributes(attributes)` : Promise
 |Name |Type |Description |
 |--- |--- |--- |
-|*attributes*|Object|Any propertites you want associated with the channel
+|*attributes*|Object|Any properties you want associated with the channel
 
 #### `setFriendlyName(friendlyName)` : Promise
 |Name |Type |Description |
@@ -72,7 +72,7 @@ Decline joining the channel, in reply to an invitation.
 #### `leave()` : Promise
 Leave a channel.
 
-#### `destory()` : Promise
+#### `destroy()` : Promise
 Delete a channel.
 
 #### `typing()`
@@ -102,7 +102,7 @@ Returns an `Array<Member>` instances.
 |--- |--- |--- |
 |*identity*|String|The identity of the user to remove
 
-#### `lastConsumedMessageIndex()` : Promise
+#### `getLastConsumedMessageIndex()` : Promise
 Returns `Number` index.
 
 #### `sendMessage(body)` : Promise
@@ -125,7 +125,7 @@ Returns an `Array<Message>` instances.
 |Name |Type |Description |
 |--- |--- |--- |
 |*index*|Number|The starting point index
-|*count*|Number|The number of preceeding messages to return
+|*count*|Number|The number of preceding messages to return
 Returns an `Array<Message>` instances.
 
 #### `getMessagesAfter(index, count)` : Promise
@@ -154,7 +154,7 @@ Returns a `Message` instance.
 #### `advanceLastConsumedMessageIndex(index)`
 |Name |Type |Description |
 |--- |--- |--- |
-|*index*|Number|The index of the message consumed (should be greated than last consumed index)
+|*index*|Number|The index of the message consumed (should be greater than last consumed index)
 
 #### `setAllMessagesConsumed()`
 Update the last consumed index for this Member and Channel to the max message currently on this device.

--- a/docs/Client.md
+++ b/docs/Client.md
@@ -1,5 +1,5 @@
 # Client
-The Client is the main interface for interacting with the Twilio SDKs. 
+The Client is the main interface for interacting with the Twilio SDKs.
 
 ## Usage
 ```JavaScript
@@ -16,7 +16,7 @@ client.initialize()
 client.onClientSynchronized = () => {
   client.getChannels()
   .then((channels) => console.log(channels))
-  
+
   // create a new channel
   client.createChannel({
     friendlyName: 'My Channel',
@@ -31,7 +31,7 @@ client.onClientSynchronized = () => {
 |Name |Type |Description |
 |--- |--- |--- |
 |*accessManager*|AccessManager|The instance of the AccessManager used to initialize the Client
-|*synchronizationStrategy*|Constants.TWMClientSynchronizationStrategy|Optional. The syncrhonization strategy to use during client initialization. Default: ChannelsList [See Twilio Docs](https://media.twiliocdn.com/sdk/ios/ip-messaging/releases/0.14.1/docs/Constants/TWMClientSynchronizationStrategy.html)
+|*synchronizationStrategy*|Constants.TWMClientSynchronizationStrategy|Optional. The synchronization strategy to use during client initialization. Default: ChannelsList [See Twilio Docs](https://media.twiliocdn.com/sdk/ios/ip-messaging/releases/0.14.1/docs/Constants/TWMClientSynchronizationStrategy.html)
 |*initialMessageCount*|Number|Optional. The number of most recent messages to fetch automatically when synchronizing a channel. Default: 100
 
 ## Properties
@@ -41,7 +41,7 @@ client.onClientSynchronized = () => {
 |*userInfo*|UserInfo|The current user properties
 |*version*|String|The version of the SDK
 |*synchronizationStatus*|Constants.TWMClientSynchronizationStatus|The current status of the client's initialization
-|*isReachabilityEnabled*|Boolean|Whether or not reacability has been enabled for the messaging instance
+|*isReachabilityEnabled*|Boolean|Whether or not reachability has been enabled for the messaging instance
 
 ## Methods
 
@@ -74,7 +74,7 @@ Get a single instance of a Channel. Returns `Channel`.
 |--- |--- |--- |
 |*friendlyName*|String|Optional. Friendly name of channel
 |*uniqueName*|String|Optional. Unique name of channel
-|*type*|Constants.TWMChannelType|Optional. Whether the channel will be private or public (default) 
+|*type*|Constants.TWMChannelType|Optional. Whether the channel will be private or public (default)
 |*attributes*|Object|Optional. Attributes to attach to the channel
 
 Create a new channel. Returns `Channel`.
@@ -103,7 +103,7 @@ Queue the incoming notification with the messaging library for processing - for 
 
 |Name |Type |Description |
 |--- |--- |--- |
-|*notification*|Object|The incomming notification.
+|*notification*|Object|The incoming notification.
 
 #### `shutdown()`
 Terminate the instance of the client, and remove all the listeners. Note: this does not remove channel specific listeners.

--- a/docs/Client.md
+++ b/docs/Client.md
@@ -91,8 +91,8 @@ Register APNS token for push notifications. This can be obtained in `PushNotific
 |--- |--- |--- |
 |*token*|String|The APNS token which usually comes from ‘didRegisterForRemoteNotificationsWithDeviceToken’.
 
-#### `deregister(token)`
-De-register from push notification updates.
+#### `unregister(token)`
+Unregister from push notification updates.
 
 |Name |Type |Description |
 |--- |--- |--- |

--- a/docs/Message.md
+++ b/docs/Message.md
@@ -19,7 +19,7 @@
 |--- |--- |--- |
 |*body*|String|The new body of the message
 
-### `setAttributes(attribtes) : Promise`
+### `setAttributes(attributes) : Promise`
 |Name |Type |Description |
 |--- |--- |--- |
 |*attributes*|Object|The new attributes to set on the message

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -242,7 +242,7 @@ class Client {
     }
 
     getChannelBySid(sid) {
-        console.warn("getChannelBySid is depreciated. Please use getChannel before upgrading to the next release.")
+        console.warn("getChannelBySid is deprecated. Please use getChannel before upgrading to the next release.")
         return TwilioIPMessagingChannels.getChannel(sid)
         .then((channel) => {
             return new Channel(channel)
@@ -291,7 +291,7 @@ class Client {
     }
 
     deregister(token) {
-        console.warn("deregister is depreciated. Use unregister before upgrading to the next release.")
+        console.warn("deregister is deprecated. Use unregister before upgrading to the next release.")
         TwilioIPMessagingClient.unregister(token)
     }
 


### PR DESCRIPTION
Just some typos and method names to fix (e.g. `lastConsumedMessageIndex` is now deprecated for `getLastConsumedMessageIndex`)
