### PR TITLE
fixed Long conversion error

### DIFF
--- a/android/src/main/java/com/bradbumbalough/RCTTwilioIPMessaging/RCTConvert.java
+++ b/android/src/main/java/com/bradbumbalough/RCTTwilioIPMessaging/RCTConvert.java
@@ -211,7 +211,7 @@ public class RCTConvert {
         WritableMap map = Arguments.createMap();
 
         map.putString("sid", message.getSid());
-        map.putString("index", String.valueOf(message.getMessageIndex()));
+        map.putString("index", (int) message.getMessageIndex());
         map.putString("author", message.getAuthor());
         map.putString("body", message.getMessageBody());
         map.putString("timestamp", message.getTimeStamp());

--- a/android/src/main/java/com/bradbumbalough/RCTTwilioIPMessaging/RCTConvert.java
+++ b/android/src/main/java/com/bradbumbalough/RCTTwilioIPMessaging/RCTConvert.java
@@ -211,7 +211,7 @@ public class RCTConvert {
         WritableMap map = Arguments.createMap();
 
         map.putString("sid", message.getSid());
-        map.putString("index", (int) message.getMessageIndex());
+        map.putInt("index", (int) message.getMessageIndex());
         map.putString("author", message.getAuthor());
         map.putString("body", message.getMessageBody());
         map.putString("timestamp", message.getTimeStamp());

--- a/android/src/main/java/com/bradbumbalough/RCTTwilioIPMessaging/RCTTwilioIPMessagingMessages.java
+++ b/android/src/main/java/com/bradbumbalough/RCTTwilioIPMessaging/RCTTwilioIPMessagingMessages.java
@@ -33,7 +33,7 @@ public class RCTTwilioIPMessagingMessages extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void getLastConsumedMessageIndex(String channelSid, Promise promise) {
-        promise.resolve(loadMessagesFromChannelSid(channelSid).getLastConsumedMessageIndex());
+        promise.resolve(Integer.valueOf(loadMessagesFromChannelSid(channelSid).getLastConsumedMessageIndex().intValue()));
     }
 
     @ReactMethod

--- a/android/src/main/java/com/bradbumbalough/RCTTwilioIPMessaging/RCTTwilioIPMessagingMessages.java
+++ b/android/src/main/java/com/bradbumbalough/RCTTwilioIPMessaging/RCTTwilioIPMessagingMessages.java
@@ -33,7 +33,12 @@ public class RCTTwilioIPMessagingMessages extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void getLastConsumedMessageIndex(String channelSid, Promise promise) {
-        promise.resolve(Integer.valueOf(loadMessagesFromChannelSid(channelSid).getLastConsumedMessageIndex().intValue()));
+        Long lastConsumedMessageIndex = loadMessagesFromChannelSid(channelSid).getLastConsumedMessageIndex();
+        if (lastConsumedMessageIndex != null) {
+            promise.resolve(Integer.valueOf(lastConsumedMessageIndex.intValue()));
+        } else {
+            promise.resolve(null);
+        }
     }
 
     @ReactMethod


### PR DESCRIPTION
The code was sometimes crashing on android with the following stack trace:

![screenshot_20161019-170237](https://cloud.githubusercontent.com/assets/22223907/19541959/7707fffc-961f-11e6-995c-cd60d9257276.png)

Upon further investigation, it appears that the getLastConsumedMessageIndex() method returns a Long, which React cannot convert to a JS-Type. Not sure if straight up conversion to an integer is the right move, but this resolved my issues.
