### PR TITLE
Fix reference of log level in android

### DIFF
--- a/android/src/main/java/com/bradbumbalough/RCTTwilioIPMessaging/RCTTwilioIPMessagingClient.java
+++ b/android/src/main/java/com/bradbumbalough/RCTTwilioIPMessaging/RCTTwilioIPMessagingClient.java
@@ -78,7 +78,6 @@ public class RCTTwilioIPMessagingClient extends ReactContextBaseJavaModule imple
         channelOption.put("Attributes", "attributes");
         constants.put("TWMChannelOption", channelOption);
 
-
         Map<String, String> logLevel = new HashMap<>();
         logLevel.put("Fatal", "Fatal");
         logLevel.put("Critical", "Critical");

--- a/android/src/main/java/com/bradbumbalough/RCTTwilioIPMessaging/RCTTwilioIPMessagingClient.java
+++ b/android/src/main/java/com/bradbumbalough/RCTTwilioIPMessaging/RCTTwilioIPMessagingClient.java
@@ -77,7 +77,16 @@ public class RCTTwilioIPMessagingClient extends ReactContextBaseJavaModule imple
         channelOption.put("Type", "type");
         channelOption.put("Attributes", "attributes");
         constants.put("TWMChannelOption", channelOption);
-        
+
+
+        Map<String, String> logLevel = new HashMap<>();
+        logLevel.put("Fatal", "Fatal");
+        logLevel.put("Critical", "Critical");
+        logLevel.put("Warning", "Warning");
+        logLevel.put("Info", "Info");
+        logLevel.put("Debug", "Debug");
+        constants.put("TWMLogLevel", channelOption);
+
         return constants;
     }
 
@@ -256,6 +265,11 @@ public class RCTTwilioIPMessagingClient extends ReactContextBaseJavaModule imple
         };
 
         tmp.client.getMyUserInfo().setAttributes(json, listener);
+    }
+
+    @ReactMethod
+    public void setLogLevel(String logLevel) {
+      // Empty body
     }
 
     // Listeners

--- a/docs/Client.md
+++ b/docs/Client.md
@@ -79,10 +79,12 @@ Get a single instance of a Channel. Returns `Channel`.
 
 Create a new channel. Returns `Channel`.
 
-#### `setLogLevel(logLevel)`
+#### `setLogLevel(logLevel)` **(iOS ONLY)**
 |Name |Type |Description |
 |--- |--- |--- |
 |*logLevel*|Constants.TWMLogLevel|Set the log level of the SDK
+
+Note: Android will ignore this configuration
 
 #### `register(token)`
 Register APNS token for push notifications. This can be obtained in `PushNotificationIOS.addListener('register', handler)`.


### PR DESCRIPTION
* Update the documentation to specify that `setLogLevel()` is only supported by iOS and will be ignored by android
* Set `TWMLogLevel` constant in android to avoid the app crashing when using them
* Create an empty method `setLogLevel()` for android so the app is not crashing when using it