### PR TITLE
Programmable Chat Android fixes

### DIFF
--- a/android/src/main/java/com/bradbumbalough/RCTTwilioChat/RCTTwilioChatChannels.java
+++ b/android/src/main/java/com/bradbumbalough/RCTTwilioChat/RCTTwilioChatChannels.java
@@ -142,15 +142,20 @@ public class RCTTwilioChatChannels extends ReactContextBaseJavaModule {
         return RCTTwilioChatClient.getInstance().client.getChannels();
     }
 
+    private void createListener(Channel channel) {
+        String sid = channel.getSid();
+        if (!channelListeners.containsKey(sid)) {
+            ChannelListener listener = generateListener(channel);
+            channel.addListener(listener);
+            channelListeners.put(sid, listener);
+        }
+    }
+
     public void loadChannelFromSid(final String sid, final CallbackListener<Channel> callback) {
         channels().getChannel(sid, new CallbackListener<Channel>() {
             @Override
             public void onSuccess(final Channel channel) {
-                if (!channelListeners.containsKey(sid)) {
-                    ChannelListener listener = generateListener(channel);
-                    channel.addListener(listener);
-                    channelListeners.put(channel.getSid(), listener);
-                }
+                createListener(channel);
                 callback.onSuccess(channel);
             };
 
@@ -173,6 +178,9 @@ public class RCTTwilioChatChannels extends ReactContextBaseJavaModule {
 
             @Override
             public void onSuccess(final Paginator<Channel> channelPaginator) {
+                for (Channel channel: channelPaginator.getItems()) {
+                    createListener(channel);
+                }
                 String uuid = RCTTwilioChatPaginator.setPaginator(channelPaginator);
                 promise.resolve(RCTConvert.Paginator(channelPaginator, uuid, "Channel"));
             }

--- a/android/src/main/java/com/bradbumbalough/RCTTwilioChat/RCTTwilioChatChannels.java
+++ b/android/src/main/java/com/bradbumbalough/RCTTwilioChat/RCTTwilioChatChannels.java
@@ -59,7 +59,7 @@ public class RCTTwilioChatChannels extends ReactContextBaseJavaModule {
                 WritableMap map = Arguments.createMap();
                 map.putString("channelSid", channelSid);
                 map.putMap("message", RCTConvert.Message(message));
-                sendEvent("ipMessagingClient:channel:messageAdded", map);
+                sendEvent("chatClient:channel:messageAdded", map);
             }
 
             @Override
@@ -68,7 +68,7 @@ public class RCTTwilioChatChannels extends ReactContextBaseJavaModule {
                 map.putString("channelSid", channelSid);
                 map.putMap("message", RCTConvert.Message(message));
 
-                sendEvent("ipMessagingClient:channel:messageChanged", map);
+                sendEvent("chatClient:channel:messageChanged", map);
             }
 
             @Override
@@ -77,7 +77,7 @@ public class RCTTwilioChatChannels extends ReactContextBaseJavaModule {
                 map.putString("channelSid", channelSid);
                 map.putMap("message", RCTConvert.Message(message));
 
-                sendEvent("ipMessagingClient:channel:messageDeleted", map);
+                sendEvent("chatClient:channel:messageDeleted", map);
             }
 
             @Override
@@ -86,7 +86,7 @@ public class RCTTwilioChatChannels extends ReactContextBaseJavaModule {
                 map.putString("channelSid", channelSid);
                 map.putMap("member", RCTConvert.Member(member));
 
-                sendEvent("ipMessagingClient:channel:memberJoined", map);
+                sendEvent("chatClient:channel:memberJoined", map);
             }
 
             @Override
@@ -95,7 +95,7 @@ public class RCTTwilioChatChannels extends ReactContextBaseJavaModule {
                 map.putString("channelSid", channelSid);
                 map.putMap("member", RCTConvert.Member(member));
 
-                sendEvent("ipMessagingClient:channel:memberChanged", map);
+                sendEvent("chatClient:channel:memberChanged", map);
             }
 
             @Override
@@ -104,7 +104,7 @@ public class RCTTwilioChatChannels extends ReactContextBaseJavaModule {
                 map.putString("channelSid", channelSid);
                 map.putMap("member", RCTConvert.Member(member));
 
-                sendEvent("ipMessagingClient:channel:memberLeft", map);
+                sendEvent("chatClient:channel:memberLeft", map);
             }
 
             @Override
@@ -113,7 +113,7 @@ public class RCTTwilioChatChannels extends ReactContextBaseJavaModule {
                 map.putString("channelSid", channelSid);
                 map.putMap("member", RCTConvert.Member(member));
 
-                sendEvent("ipMessagingClient:typingStartedOnChannel", map);
+                sendEvent("chatClient:typingStartedOnChannel", map);
             }
 
             @Override
@@ -122,7 +122,7 @@ public class RCTTwilioChatChannels extends ReactContextBaseJavaModule {
                 map.putString("channelSid", channelSid);
                 map.putMap("member", RCTConvert.Member(member));
 
-                sendEvent("ipMessagingClient:typingEndedOnChannel", map);
+                sendEvent("chatClient:typingEndedOnChannel", map);
             }
 
             @Override
@@ -131,7 +131,7 @@ public class RCTTwilioChatChannels extends ReactContextBaseJavaModule {
                 map.putString("channelSid", channelSid);
                 map.putString("status", channel.getSynchronizationStatus().toString());
 
-                sendEvent("ipMessagingClient:channel:synchronizationStatusChanged", map);
+                sendEvent("chatClient:channel:synchronizationStatusChanged", map);
             }
         };
 

--- a/android/src/main/java/com/bradbumbalough/RCTTwilioChat/RCTTwilioChatClient.java
+++ b/android/src/main/java/com/bradbumbalough/RCTTwilioChat/RCTTwilioChatClient.java
@@ -88,12 +88,11 @@ public class RCTTwilioChatClient extends ReactContextBaseJavaModule implements C
         constants.put("TCHClientConnectionState", connectionState);
 
         Map<String, Integer> logLevel = new HashMap<>();
-        logLevel.put("Assert", Log.ASSERT);
-        logLevel.put("Debug", Log.DEBUG);
-        logLevel.put("Error", Log.ERROR);
+        logLevel.put("Fatal", Log.ERROR);
+        logLevel.put("Critical", Log.ERROR);
+        logLevel.put("Warning", Log.WARN);
         logLevel.put("Info", Log.INFO);
-        logLevel.put("Verbose", Log.VERBOSE);
-        logLevel.put("Warn", Log.WARN);
+        logLevel.put("Debug", Log.DEBUG);
         constants.put("TCHLogLevel", logLevel);
 
         Map<String, String> userInfo = new HashMap<>();
@@ -240,8 +239,7 @@ public class RCTTwilioChatClient extends ReactContextBaseJavaModule implements C
 
     @ReactMethod
     public void setLogLevel(Integer logLevel) {
-        RCTTwilioChatClient tmp = RCTTwilioChatClient.getInstance();
-        tmp.client.setLogLevel(logLevel);
+        ChatClient.setLogLevel(logLevel);
     }
 
     // UserInfo methods

--- a/android/src/main/java/com/bradbumbalough/RCTTwilioChat/RCTTwilioChatClient.java
+++ b/android/src/main/java/com/bradbumbalough/RCTTwilioChat/RCTTwilioChatClient.java
@@ -87,7 +87,7 @@ public class RCTTwilioChatClient extends ReactContextBaseJavaModule implements C
         connectionState.put("Error", ChatClient.ConnectionState.FATAL_ERROR.toString());
         constants.put("TCHClientConnectionState", connectionState);
 
-        Map<String, String> logLevel = new HashMap<>();
+        Map<String, Integer> logLevel = new HashMap<>();
         logLevel.put("Assert", Log.ASSERT);
         logLevel.put("Debug", Log.DEBUG);
         logLevel.put("Error", Log.ERROR);

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -16,6 +16,7 @@ function getConstants() {
       TCHChannelOption: TwilioChatClient.TCHChannelOption,
       TCHClientSynchronizationStatus: TwilioChatClient.TCHClientSynchronizationStatus,
       TCHClientSynchronizationStrategy: TwilioChatClient.TCHClientSynchronizationStrategy,
+      TCHLogLevel: TwilioChatClient.TCHLogLevel,
     };
   }
   return TwilioChatClient.Constants;


### PR DESCRIPTION
We were trying to integrate your current version of programmable chat and we noticed we were getting a few errors, specifically relating to the setLogLevel method in the client and the event listeners on channels.

Essentially we changed the log level constants to match the names and values of those in iOS as closely as possible and we changed the names of the events being sent from the bridge to be prefixed with chatClient instead of ipMessagingClient.