### PR TITLE
anroid: clear channelListeners map on shutdown

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,6 +13,6 @@ android {
 }
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile "com.twilio:chat-android:0.11.0"
+    compile "com.twilio:chat-android:0.11.2"
     compile "com.twilio:accessmanager-android:0.1.0"
 }

--- a/android/src/main/java/com/bradbumbalough/RCTTwilioChat/RCTTwilioChatChannels.java
+++ b/android/src/main/java/com/bradbumbalough/RCTTwilioChat/RCTTwilioChatChannels.java
@@ -37,7 +37,7 @@ public class RCTTwilioChatChannels extends ReactContextBaseJavaModule {
     }
 
     private ReactApplicationContext reactContext;
-    private HashMap<String,ChannelListener> channelListeners = new HashMap<String, ChannelListener>();
+    private Map<String,ChannelListener> channelListeners = new HashMap<String, ChannelListener>();
 
     public RCTTwilioChatChannels(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -554,6 +554,11 @@ public class RCTTwilioChatChannels extends ReactContextBaseJavaModule {
                 });
             }
         });
+    }
+
+    @ReactMethod
+    public void shutdown() {
+        channelListeners.clear();
     }
 
 

--- a/android/src/main/java/com/bradbumbalough/RCTTwilioChat/RCTTwilioChatClient.java
+++ b/android/src/main/java/com/bradbumbalough/RCTTwilioChat/RCTTwilioChatClient.java
@@ -293,7 +293,7 @@ public class RCTTwilioChatClient extends ReactContextBaseJavaModule implements C
     }
 
     @Override
-    public void onChannelAdd(Channel channel) {
+    public void onChannelAdd(final Channel channel) {
         sendEvent("chatClient:channelAdded", RCTConvert.Channel(channel));
     }
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -304,8 +304,10 @@ class Client {
 
   shutdown() {
     TwilioChatClient.shutdown();
+    if (Platform.OS === 'android') {
+      TwilioChatChannels.shutdown();
+    }
     this._removeListeners();
-    this.accessManager.removeListeners();
   }
 
   _removeListeners() {


### PR DESCRIPTION
The channelListeners hashmap was not being cleared anywhere. This resulted in some strange bugs  where if the user signed out of the app, and then back in, they could send messages, but we were no longer receiving messages from the channel.

Clearing the hashmap with a shutdown function during the shutdown process seemed to fix it.

Note: Bug was not appearing on iOS.