### PR TITLE
fix synchronizationStrategy always defaulting to 1

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -49,7 +49,7 @@ class Client {
 
     this.onClientSynchronized = null;
     this._properties = {
-      synchronizationStrategy: synchronizationStrategy ? synchronizationStrategy : Constants.TCHClientSynchronizationStrategy.ChannelsList,
+      synchronizationStrategy: synchronizationStrategy !== null ? synchronizationStrategy : Constants.TCHClientSynchronizationStrategy.ChannelsList,
       initialMessageCount: initialMessageCount ? initialMessageCount : 100,
     };
 


### PR DESCRIPTION
`synchronizationStrategy: synchronizationStrategy ? synchronizationStrategy : Constants.TCHClientSynchronizationStrategy.ChannelsList` will always result in 1 even if 0 is explicitly passed into constructor.  Updated `_properties` defaults logic to distinguish `null` from `0`