### PR TITLE
Fixed React pod path for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 Install the Twilio Programable Chat SDK and this package via CocoaPods.
 
 ```
+pod 'React', :subspecs => ['Core', 'RCTActionSheet', 'RCTGeolocation', 'RCTImage', 'RCTLinkingIOS', 'RCTNetwork', 'RCTText', 'RCTSettings', 'RCTAnimation', 'RCTVibration', 'RCTWebSocket'], :path => '../node_modules/react-native'
 pod 'RCTTwilioChat', :path => '../node_modules/react-native-twilio-ip-messaging/ios'
   
 source 'https://github.com/twilio/cocoapod-specs'


### PR DESCRIPTION
I've added a custom path for the React pod in the installation instructions, because otherwise Cocoapods installs the old 0.11.0 React pod, which is deprecated.